### PR TITLE
add cluster connect timeout setting

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -88,6 +88,8 @@ cluster_secret: ${CLUSTER_SECRET}
 sync_interval: 10
 # 同步文件时最多打开的连接数量
 download_max_conn: 64
+# 连接超时限制（秒），网不好就调高点
+connect_timeout: 10
 # 服务器上行限制
 serve_limit:
   # 是否启用上行限制

--- a/cluster.go
+++ b/cluster.go
@@ -212,7 +212,7 @@ func (cr *Cluster) Enable(ctx context.Context) (err error) {
 		return
 	}
 	logInfo("Sending enable packet")
-	tctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	tctx, cancel := context.WithTimeout(ctx, time.Second * time.Duration(config.ConnectTimeout))
 	data, err := cr.socket.EmitAckContext(tctx, "enable", Map{
 		"host":    cr.host,
 		"port":    cr.publicPort,

--- a/config.go
+++ b/config.go
@@ -68,6 +68,7 @@ type Config struct {
 	ClusterSecret   string           `yaml:"cluster_secret"`
 	SyncInterval    int              `yaml:"sync_interval"`
 	DownloadMaxConn int              `yaml:"download_max_conn"`
+	ConnectTimeout  int              `yaml:"connect_timeout"`
 	ServeLimit      ServeLimitConfig `yaml:"serve_limit"`
 	Oss             OSSConfig        `yaml:"oss"`
 	Hijack          HijackConfig     `yaml:"hijack_port"`
@@ -87,6 +88,7 @@ func readConfig() (config Config) {
 		ClusterSecret:   "${CLUSTER_SECRET}",
 		SyncInterval:    10,
 		DownloadMaxConn: 64,
+		ConnectTimeout:  10,
 		ServeLimit: ServeLimitConfig{
 			Enable:     false,
 			MaxConn:    16384,

--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,7 @@ cluster_id: ${CLUSTER_ID}
 cluster_secret: ${CLUSTER_SECRET}
 sync_interval: 10
 download_max_conn: 64
+connect_timeout: 60
 serve_limit:
     enable: false
     max_conn: 0


### PR DESCRIPTION
Sometimes the cluster cannot start due to bad network environment. So add this setting to modify timeout.