### PR TITLE
将容器运行脚本的网络模式改为host而不是单独开放port

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -11,7 +11,7 @@ docker pull craftmine/go-openbmclapi:latest || {
 }
 
 docker run -d --name my-go-openbmclapi \
-	--network=host \ 
+	--net=host \ 
 	-e CLUSTER_ID=${CLUSTER_ID} \
 	-e CLUSTER_SECRET=${CLUSTER_SECRET} \
 	-e CLUSTER_IP=${CLUSTER_IP} \

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -11,9 +11,9 @@ docker pull craftmine/go-openbmclapi:latest || {
 }
 
 docker run -d --name my-go-openbmclapi \
+	--network=host \ 
 	-e CLUSTER_ID=${CLUSTER_ID} \
 	-e CLUSTER_SECRET=${CLUSTER_SECRET} \
-	-e CLUSTER_PUBLIC_PORT=${CLUSTER_PUBLIC_PORT} \
 	-e CLUSTER_IP=${CLUSTER_IP} \
 	-v "${PWD}/cache":/opt/openbmclapi/cache \
 	-v "${PWD}/data":/opt/openbmclapi/data \


### PR DESCRIPTION
如题，本人在用这个脚本建容器的时候经常会遇到firewalld关了路由器放规则了最后还是连不上的问题（
最后发现是容器端口配置问题，加上go-openbmclapi的容器也没有什么敏感的端口（21 22 e.t.c）为什么不直接把容器网络类型改成host呢（